### PR TITLE
[6일차] QuerydslPredicateExecutor,QuerydslRepositorySupport 학습

### DIFF
--- a/jiyoul/src/main/java/study/querydsl/repository/MemberRepository.java
+++ b/jiyoul/src/main/java/study/querydsl/repository/MemberRepository.java
@@ -1,11 +1,12 @@
 package study.querydsl.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import study.querydsl.entity.Member;
 
 import java.util.List;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom, QuerydslPredicateExecutor<Member> {
 
     List<Member> findByUsername(String username);
 }

--- a/jiyoul/src/main/java/study/querydsl/repository/MemberRepositoryImpl.java
+++ b/jiyoul/src/main/java/study/querydsl/repository/MemberRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 import study.querydsl.dto.MemberSearchCondition;
@@ -23,8 +24,8 @@ import static study.querydsl.entity.QMember.member;
 import static study.querydsl.entity.QTeam.team;
 
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
-    private final JPAQueryFactory queryFactory;
 
+    private final JPAQueryFactory queryFactory;
     public MemberRepositoryImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }

--- a/jiyoul/src/main/java/study/querydsl/repository/MemberTestRepository.java
+++ b/jiyoul/src/main/java/study/querydsl/repository/MemberTestRepository.java
@@ -1,0 +1,95 @@
+package study.querydsl.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.support.PageableExecutionUtils;
+import study.querydsl.dto.MemberSearchCondition;
+import study.querydsl.entity.Member;
+import study.querydsl.entity.QMember;
+import study.querydsl.repository.support.Querydsl4RepositorySupport;
+
+import java.util.List;
+
+import static com.querydsl.jpa.JPAExpressions.select;
+import static org.springframework.util.StringUtils.hasText;
+import static study.querydsl.entity.QMember.member;
+import static study.querydsl.entity.QTeam.team;
+
+public class MemberTestRepository extends Querydsl4RepositorySupport {
+
+    public MemberTestRepository() {
+        super(Member.class);
+    }
+
+    public List<Member> basicSelect() {
+        return select(member)
+                .from(member)
+                .fetch();
+    }
+
+    public List<Member> basicSelectFrom() {
+        return select(member)
+                .fetch();
+    }
+
+    public Page<Member> searchPageByApplyPage(MemberSearchCondition condition, Pageable pageable) {
+        JPAQuery<Member> query = selectFrom(member)
+                .leftJoin(member.team, team)
+                .where(usernameEq(condition.getUsername()),
+                        teamNameEq(condition.getTeamName()),
+                        ageGoe(condition.getAgeGoe()),
+                        ageLoe(condition.getAgeLoe()));
+
+        List<Member> content = getQuerydsl().applyPagination(pageable, query).fetch();
+
+        return PageableExecutionUtils.getPage(content, pageable, query::fetchCount);
+    }
+
+    public Page<Member> applyPagination(MemberSearchCondition condition, Pageable pageable) {
+        return applyPagination(pageable, contentQuery -> contentQuery
+                .selectFrom(member)
+                .leftJoin(member.team, team)
+                .where(usernameEq(condition.getUsername()),
+                        teamNameEq(condition.getTeamName()),
+                        ageGoe(condition.getAgeGoe()),
+                        ageLoe(condition.getAgeLoe())));
+    }
+
+    public Page<Member> applyPagination2(MemberSearchCondition condition, Pageable pageable) {
+        return applyPagination(pageable, contentQuery -> contentQuery
+                        .selectFrom(member)
+                        .leftJoin(member.team, team)
+                        .where(usernameEq(condition.getUsername()),
+                                teamNameEq(condition.getTeamName()),
+                                ageGoe(condition.getAgeGoe()),
+                                ageLoe(condition.getAgeLoe())),
+                countQuery -> countQuery
+                        .selectFrom(member)
+                        .leftJoin(member.team, team)
+                        .where(usernameEq(condition.getUsername()),
+                                teamNameEq(condition.getTeamName()),
+                                ageGoe(condition.getAgeGoe()),
+                                ageLoe(condition.getAgeLoe()))
+        );
+    }
+
+    private BooleanExpression usernameEq(String username) {
+        return hasText(username) ? member.username.eq(username) : null;
+    }
+
+    private BooleanExpression teamNameEq(String teamName) {
+        return hasText(teamName) ? team.name.eq(teamName) : null;
+    }
+
+    private BooleanExpression ageGoe(Integer ageGoe) {
+        return ageGoe == null ? null : member.age.goe(ageGoe);
+    }
+
+    private BooleanExpression ageLoe(Integer ageLoe) {
+        return ageLoe == null ? null : member.age.loe(ageLoe);
+    }
+
+}

--- a/jiyoul/src/main/java/study/querydsl/repository/support/Querydsl4RepositorySupport.java
+++ b/jiyoul/src/main/java/study/querydsl/repository/support/Querydsl4RepositorySupport.java
@@ -1,0 +1,96 @@
+package study.querydsl.repository.support;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Querydsl 4.x 버전에 맞춘 Querydsl 지원 라이브러리
+ * @author Younghan Kim
+ * @see org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+ */
+@Repository
+public abstract class Querydsl4RepositorySupport {
+    private final Class domainClass;
+    private Querydsl querydsl;
+    private EntityManager entityManager;
+    private JPAQueryFactory queryFactory;
+
+    public Querydsl4RepositorySupport(Class<?> domainClass) {
+        Assert.notNull(domainClass, "Domain class must not be null!");
+        this.domainClass = domainClass;
+    }
+
+    @Autowired
+    public void setEntityManager(EntityManager entityManager) {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+
+        JpaEntityInformation entityInformation = JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+
+        SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+        EntityPath path = resolver.createPath(entityInformation.getJavaType());
+
+        this.entityManager = entityManager;
+        this.querydsl = new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @PostConstruct
+    public void validate() {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+        Assert.notNull(querydsl, "Querydsl must not be null!");
+        Assert.notNull(queryFactory, "QueryFactory must not be null!");
+    }
+
+    protected JPAQueryFactory getQueryFactory() {
+        return queryFactory;
+    }
+
+    protected Querydsl getQuerydsl() {
+        return querydsl;
+    }
+
+    protected EntityManager getEntityManager() {
+        return entityManager;
+    }
+
+    protected <T> JPAQuery<T> select(Expression<T> expr) {
+        return getQueryFactory().select(expr);
+    }
+
+    protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+        return getQueryFactory().selectFrom(from);
+    }
+
+    protected <T> Page<T> applyPagination(Pageable pageable, Function<JPAQueryFactory, JPAQuery> contentQuery) {
+        JPAQuery jpaQuery = contentQuery.apply(getQueryFactory());
+        List<T> content = getQuerydsl().applyPagination(pageable, jpaQuery).fetch();
+        return PageableExecutionUtils.getPage(content, pageable, jpaQuery::fetchCount);
+    }
+
+    protected <T> Page<T> applyPagination(Pageable pageable, Function<JPAQueryFactory, JPAQuery> contentQuery, Function<JPAQueryFactory, JPAQuery> countQuery) {
+        JPAQuery jpaContentQuery = contentQuery.apply(getQueryFactory());
+        List<T> content = getQuerydsl().applyPagination(pageable, jpaContentQuery).fetch();
+        JPAQuery countResult = countQuery.apply(getQueryFactory());
+
+        return PageableExecutionUtils.getPage(content, pageable, countResult::fetchCount);
+    }
+
+}

--- a/jiyoul/src/test/java/study/querydsl/repository/MemberRepositoryTest.java
+++ b/jiyoul/src/test/java/study/querydsl/repository/MemberRepositoryTest.java
@@ -5,10 +5,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.transaction.annotation.Transactional;
 import study.querydsl.dto.MemberSearchCondition;
 import study.querydsl.dto.MemberTeamDto;
 import study.querydsl.entity.Member;
+import study.querydsl.entity.QMember;
 import study.querydsl.entity.Team;
 
 import javax.persistence.EntityManager;
@@ -94,5 +96,34 @@ class MemberRepositoryTest {
 
         assertThat(result.getSize()).isEqualTo(3);
         assertThat(result).extracting("username").containsExactly("member1", "member2", "member3");
+    }
+
+    // QuerydslPredicateExecutor는 join은 되긴되는데 힘들어서 실무에선 사용을 잘 안한다. Pagable, Sort는 잘 동작함.
+    @Test
+    public void querydslPredicateExecutorTest() throws Exception {
+        Team teamA = new Team("teamA");
+        Team teamB = new Team("teamB");
+
+        em.persist(teamA);
+        em.persist(teamB);
+
+        Member member1 = new Member("member1", 10, teamA);
+        Member member2 = new Member("member2", 20, teamA);
+        Member member3 = new Member("member3", 30, teamB);
+        Member member4 = new Member("member4", 40, teamB);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+
+        QMember qMember = QMember.member;
+
+        // QuerydslPredicateExecutor 사용
+        Iterable<Member> members = memberRepository.findAll(qMember.age.between(20, 40).and(qMember.username.eq("member1")));
+        for (Member member : members) {
+            System.out.println("member = " + member);
+        }
+
     }
 }


### PR DESCRIPTION
QuerydslRepositorySupport, QuerydslPredicateExecutor 등 학습
QuerydslRepositorySupport는 따로 paging 로직을 만들어둬서(Querydsl4RepositorySupport)

 람다로 넘기면 개발시에 간단하게 페이징 구현도 가능함.